### PR TITLE
Add vhost support for AMQP connector

### DIFF
--- a/connectors/amqp/amqptype/amqptype.go
+++ b/connectors/amqp/amqptype/amqptype.go
@@ -4,5 +4,6 @@ type Amqp struct {
 	User     string
 	Password string
 	Host     string
+	Vhost    string
 	Port     int
 }

--- a/connectors/amqp/client/amqp_connector.go
+++ b/connectors/amqp/client/amqp_connector.go
@@ -1,12 +1,12 @@
 package client
 
 import (
-	"github.com/cloudfoundry-community/gautocloud/connectors"
-	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/raw"
-	"github.com/streadway/amqp"
 	"fmt"
 	"github.com/cloudfoundry-community/gautocloud"
+	"github.com/cloudfoundry-community/gautocloud/connectors"
 	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/amqptype"
+	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/raw"
+	"github.com/streadway/amqp"
 )
 
 func init() {
@@ -36,7 +36,7 @@ func (c AmqpConnector) GetConnString(schema amqptype.Amqp) string {
 	if schema.Password != "" {
 		connString += ":" + schema.Password
 	}
-	connString += fmt.Sprintf("@%s:%d/", schema.Host, schema.Port)
+	connString += fmt.Sprintf("@%s:%d/%s", schema.Host, schema.Port, schema.Vhost)
 	return connString
 }
 func (c AmqpConnector) Load(schema interface{}) (interface{}, error) {
@@ -49,6 +49,3 @@ func (c AmqpConnector) Load(schema interface{}) (interface{}, error) {
 func (c AmqpConnector) Schema() interface{} {
 	return c.rawConn.Schema()
 }
-
-
-

--- a/connectors/amqp/client/amqp_connector_test.go
+++ b/connectors/amqp/client/amqp_connector_test.go
@@ -3,34 +3,47 @@ package client_test
 import (
 	. "github.com/cloudfoundry-community/gautocloud/connectors/amqp/client"
 
+	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/amqptype"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/amqptype"
 )
 
 var _ = Describe("AmqpConnector", func() {
 	Context("GetConnString", func() {
-		mysqlConnector := AmqpConnector{}
+		amqpConnector := AmqpConnector{}
 		Context("When there is no password given", func() {
 			It("should return correct connection string", func() {
-				connString := mysqlConnector.GetConnString(amqptype.Amqp{
+				connString := amqpConnector.GetConnString(amqptype.Amqp{
 					Host: "localhost",
-					Port: 3306,
+					Port: 5672,
 					User: "user",
 				})
-				Expect(connString).Should(Equal("amqp://user@localhost:3306/"))
+				Expect(connString).Should(Equal("amqp://user@localhost:5672/"))
 			})
 		})
 		Context("When there is password given", func() {
 			It("should return correct connection string", func() {
-				connString := mysqlConnector.GetConnString(amqptype.Amqp{
-					Host: "localhost",
-					Port: 3306,
-					User: "user",
+				connString := amqpConnector.GetConnString(amqptype.Amqp{
+					Host:     "localhost",
+					Port:     5672,
+					User:     "user",
 					Password: "pass",
 				})
-				Expect(connString).Should(Equal("amqp://user:pass@localhost:3306/"))
+				Expect(connString).Should(Equal("amqp://user:pass@localhost:5672/"))
 			})
 		})
+		Context("When there is vhost given", func() {
+			It("should return correct connection string", func() {
+				connString := amqpConnector.GetConnString(amqptype.Amqp{
+					Host:     "localhost",
+					Port:     5672,
+					User:     "user",
+					Password: "pass",
+					Vhost:    "foo",
+				})
+				Expect(connString).Should(Equal("amqp://user:pass@localhost:5672/foo"))
+			})
+		})
+
 	})
 })

--- a/connectors/amqp/raw/amqp_connector.go
+++ b/connectors/amqp/raw/amqp_connector.go
@@ -39,7 +39,7 @@ func (c AmqpRawConnector) Load(schema interface{}) (interface{}, error) {
 		User:     fSchema.Uri.Username,
 		Password: fSchema.Uri.Password,
 		Host:     fSchema.Uri.Host,
-		Vhost:    fSchema.Vhost,
+		Vhost:    fSchema.Uri.Name,
 		Port:     port,
 	}, nil
 }

--- a/connectors/amqp/raw/amqp_connector.go
+++ b/connectors/amqp/raw/amqp_connector.go
@@ -2,8 +2,8 @@ package raw
 
 import (
 	"github.com/cloudfoundry-community/gautocloud/connectors"
-	. "github.com/cloudfoundry-community/gautocloud/connectors/amqp/schema"
 	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/amqptype"
+	. "github.com/cloudfoundry-community/gautocloud/connectors/amqp/schema"
 )
 
 type AmqpRawConnector struct{}
@@ -24,10 +24,11 @@ func (c AmqpRawConnector) Load(schema interface{}) (interface{}, error) {
 	fSchema := schema.(AmqpSchema)
 	if fSchema.Uri.Host == "" {
 		return amqptype.Amqp{
-			User: fSchema.User,
+			User:     fSchema.User,
 			Password: fSchema.Password,
-			Host: fSchema.Host,
-			Port: fSchema.Port,
+			Host:     fSchema.Host,
+			Port:     fSchema.Port,
+			Vhost:    fSchema.Vhost,
 		}, nil
 	}
 	port := fSchema.Uri.Port
@@ -35,10 +36,11 @@ func (c AmqpRawConnector) Load(schema interface{}) (interface{}, error) {
 		port = fSchema.Port
 	}
 	return amqptype.Amqp{
-		User: fSchema.Uri.Username,
+		User:     fSchema.Uri.Username,
 		Password: fSchema.Uri.Password,
-		Host: fSchema.Uri.Host,
-		Port: port,
+		Host:     fSchema.Uri.Host,
+		Vhost:    fSchema.Vhost,
+		Port:     port,
 	}, nil
 }
 func (c AmqpRawConnector) Schema() interface{} {

--- a/connectors/amqp/raw/amqp_connector_test.go
+++ b/connectors/amqp/raw/amqp_connector_test.go
@@ -3,12 +3,12 @@ package raw_test
 import (
 	. "github.com/cloudfoundry-community/gautocloud/connectors/amqp/raw"
 
+	"github.com/cloudfoundry-community/gautocloud/connectors"
+	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/amqptype"
+	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/schema"
+	"github.com/cloudfoundry-community/gautocloud/decoder"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/cloudfoundry-community/gautocloud/decoder"
-	"github.com/cloudfoundry-community/gautocloud/connectors"
-	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/schema"
-	"github.com/cloudfoundry-community/gautocloud/connectors/amqp/amqptype"
 )
 
 var _ = Describe("AmqpConnector", func() {
@@ -18,37 +18,39 @@ var _ = Describe("AmqpConnector", func() {
 	})
 	It("Should return a Amqp struct when passing a AmqpSchema without uri", func() {
 		data, err := connector.Load(schema.AmqpSchema{
-			Host: "localhost",
+			Host:     "localhost",
 			Password: "pass",
-			User: "user",
-			Port: 3306,
+			User:     "user",
+			Port:     5672,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).Should(BeEquivalentTo(
 			amqptype.Amqp{
-				Host: "localhost",
+				Host:     "localhost",
 				Password: "pass",
-				User: "user",
-				Port: 3306,
+				User:     "user",
+				Port:     5672,
 			},
 		))
 	})
 	It("Should return a Amqp struct when passing a AmqpSchema with an uri", func() {
 		data, err := connector.Load(schema.AmqpSchema{
 			Uri: decoder.ServiceUri{
-				Host: "localhost",
+				Host:     "localhost",
 				Username: "user",
 				Password: "pass",
-				Port: 3306,
+				Port:     5672,
 			},
+			Vhost: "foo",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).Should(BeEquivalentTo(
 			amqptype.Amqp{
-				Host: "localhost",
+				Host:     "localhost",
 				Password: "pass",
-				User: "user",
-				Port: 3306,
+				User:     "user",
+				Port:     5672,
+				Vhost:    "foo",
 			},
 		))
 	})

--- a/connectors/amqp/raw/amqp_connector_test.go
+++ b/connectors/amqp/raw/amqp_connector_test.go
@@ -40,8 +40,8 @@ var _ = Describe("AmqpConnector", func() {
 				Username: "user",
 				Password: "pass",
 				Port:     5672,
+				Name:     "foo",
 			},
-			Vhost: "foo",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).Should(BeEquivalentTo(

--- a/connectors/amqp/schema/schema.go
+++ b/connectors/amqp/schema/schema.go
@@ -4,8 +4,9 @@ import "github.com/cloudfoundry-community/gautocloud/decoder"
 
 type AmqpSchema struct {
 	Uri      decoder.ServiceUri `cloud:"ur(i|l),regex"`
-	Port     int `cloud:"" cloud-default:"5672"`
-	Host     string `cloud:".*host.*,regex" cloud-default:"localhost"`
-	User     string `cloud:".*user.*,regex" cloud-default:"root"`
-	Password string `cloud:".*pass.*,regex"`
+	Port     int                `cloud:"" cloud-default:"5672"`
+	Host     string             `cloud:"host.*,regex" cloud-default:"localhost"`
+	User     string             `cloud:".*user.*,regex" cloud-default:"root"`
+	Password string             `cloud:".*pass.*,regex"`
+	Vhost    string             `cloud:"vhost.*,regex"`
 }


### PR DESCRIPTION
This adds vhost support to the AMQP connector. Tested with local cloud and the open source Cloud foundry release and the multi-tenant cf-rabbitmq broker.