### PR TITLE
Exact match for host. Partially fixes #2

### DIFF
--- a/connectors/amqp/schema/schema.go
+++ b/connectors/amqp/schema/schema.go
@@ -5,7 +5,7 @@ import "github.com/cloudfoundry-community/gautocloud/decoder"
 type AmqpSchema struct {
 	Uri      decoder.ServiceUri `cloud:"ur(i|l),regex"`
 	Port     int                `cloud:"" cloud-default:"5672"`
-	Host     string             `cloud:"host.*,regex" cloud-default:"localhost"`
+	Host     string             `cloud:"hostname" cloud-default:"localhost"`
 	User     string             `cloud:".*user.*,regex" cloud-default:"root"`
 	Password string             `cloud:".*pass.*,regex"`
 	Vhost    string             `cloud:"vhost.*,regex"`


### PR DESCRIPTION
This PR fixes the random crashes I'm observing when using gautocloud. The broker credentials structure contains the following entries:

```json
...
     "hostname": "172.47.29.219",
     "hostnames": [
         "172.47.29.219"
     ],
...
```

When debugging with delve I'm seeing that the crash occurs when the schema matches on the `hostnames` field. It expects a string but because it's an array it crashes in the introspect flow. I haven't delved too deeply into this part of the code to figure out how to fix this. Also, I'm not sure what the overall strategy is for matching fields. So this PR simply ensures only `hostname` ever matches.